### PR TITLE
【Fixed】Feature/issues #1

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
   # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -19,6 +20,12 @@ class AgendasController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    return flash[:notice] = I18n.t('views.messages.you_do_not_have_permission') unless current_user == @agenda.user || current_user == @agenda.team.owner
+    @agenda.destroy
+    redirect_to teams_url, notice: I18n.t('views.messages.destroy_agenda')
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -24,8 +24,9 @@ class AgendasController < ApplicationController
 
   def destroy
     return flash[:notice] = I18n.t('views.messages.you_do_not_have_permission') unless current_user == @agenda.user || current_user == @agenda.team.owner
+    AgendaMailer.destroy_mail(@agenda).deliver
     @agenda.destroy
-    redirect_to teams_url, notice: I18n.t('views.messages.destroy_agenda')
+    redirect_to dashboard_path, notice: I18n.t('views.messages.destroy_agenda')
   end
 
   private

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -62,8 +62,8 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(_team_id)
+  def find_team(*)
     # team = Team.friendly.find(params[:team_id])
-    Team.friendly.find(params[:_team_id])
+    Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -62,7 +62,8 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
-    team = Team.friendly.find(params[:team_id])
+  def find_team(_team_id)
+    # team = Team.friendly.find(params[:team_id])
+    Team.friendly.find(params[:_team_id])
   end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,2 +1,9 @@
 class AgendaMailer < ApplicationMailer
+  default from: 'admin@example.com'
+  layout 'mailer'
+
+  def destroy_mail(agenda)
+    @agenda = agenda
+    mail to: agenda.team.users.pluck(:email), subject: I18n.t("views.messages.agenda_destroy_notice")
+  end
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,2 @@
+class AgendaMailer < ApplicationMailer
+end

--- a/app/views/agenda_mailer/destroy_mail.html.erb
+++ b/app/views/agenda_mailer/destroy_mail.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('views.messages.destroy_agenda') %></h1>
+<h1></h1>
+<h4>title: <%= @agenda.title %></h4>
+<h4><%= t('views.messages.agenda_content') %></h4>
+<p>content: <%= @agenda.description %></p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <div class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <%= link_to t('views.button.delete'), agenda, method: :delete, data: {confirm: I18n.t('devise.registrations.edit.are_you_sure')}, class:"nav-link d-inline-flex" %>
                 <i class="right fa fa-angle-left"></i>
               </p>
-            </a>
+            </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,7 +205,9 @@ ja:
     pm: 午後
   views:
     messages:
+      you_do_not_have_permission: '権限がありません。'
       create_agenda: 'アジェンダ作成に成功しました！'
+      destroy_agenda: 'アジェンダを削除しました。'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
       assigned: 'アサインしました！'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,6 +205,8 @@ ja:
     pm: 午後
   views:
     messages:
+      agenda_content: 'アジェンダの内容'
+      agenda_destroy_notice: 'アジェンダ削除のお知らせ'
       you_do_not_have_permission: '権限がありません。'
       create_agenda: 'アジェンダ作成に成功しました！'
       destroy_agenda: 'アジェンダを削除しました。'

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
以下の実装が終わりました。

 AgendasControllerのdestroyアクションを追加し、そこに機能追加する
 Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
 Agendaに紐づいているarticleも一緒に削除される
 Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
 Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
 情報処理が完了した後はDashBoardに飛ぶ
 その他、アプリケーションの挙動に不審な点やエラーがないこと

確認をお願い致します。